### PR TITLE
:bug: Add DEF 14A to filing_types.FilingType

### DIFF
--- a/secedgar/filings/filing_types.py
+++ b/secedgar/filings/filing_types.py
@@ -60,6 +60,7 @@ class FilingType(Enum):
     FILING_CFPORTAL = 'cfportal'
     FILING_CUSTODY = 'custody'
     FILING_D = 'd'
+    FILING_DEF_14A = 'def 14a'
     FILING_F1 = 'f-1'
     FILING_F10 = 'f-10'
     FILING_F3 = 'f-3'


### PR DESCRIPTION
It is referenced in the docs but not included in the Enum class. 
https://www.rudrakos.com/sec-edgar/filingtypes.html#form-def-14a

The space is needed when searching on edgar.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/whatsnew latest version